### PR TITLE
Move expression continuations onto a single line

### DIFF
--- a/Arduboy2/Arduboy2.cpp
+++ b/Arduboy2/Arduboy2.cpp
@@ -939,8 +939,7 @@ void Arduboy2Base::drawCompressed(int16_t sx, int16_t sy, const uint8_t *bitmap,
         int bRow = startRow + rowOffset;
 
         //if (byte) // possible optimisation
-        if ((bRow <= (HEIGHT / 8) - 1) && (bRow > -2) &&
-            (columnOffset + sx <= (WIDTH - 1)) && (columnOffset + sx >= 0))
+        if ((bRow <= (HEIGHT / 8) - 1) && (bRow > -2) && (columnOffset + sx <= (WIDTH - 1)) && (columnOffset + sx >= 0))
         {
           int16_t offset = (bRow * WIDTH) + sx + columnOffset;
           if (bRow >= 0)
@@ -1026,22 +1025,17 @@ bool Arduboy2Base::justReleased(uint8_t button)
 
 bool Arduboy2Base::collide(Point point, Rect rect)
 {
-  return ((point.x >= rect.x) && (point.x < rect.x + rect.width) &&
-      (point.y >= rect.y) && (point.y < rect.y + rect.height));
+  return ((point.x >= rect.x) && (point.x < rect.x + rect.width) && (point.y >= rect.y) && (point.y < rect.y + rect.height));
 }
 
 bool Arduboy2Base::collide(Rect rect1, Rect rect2)
 {
-  return !(rect2.x                >= rect1.x + rect1.width  ||
-           rect2.x + rect2.width  <= rect1.x                ||
-           rect2.y                >= rect1.y + rect1.height ||
-           rect2.y + rect2.height <= rect1.y);
+  return !(rect2.x >= rect1.x + rect1.width || rect2.x + rect2.width <= rect1.x || rect2.y >= rect1.y + rect1.height || rect2.y + rect2.height <= rect1.y);
 }
 
 uint16_t Arduboy2Base::readUnitID()
 {
-  return EEPROM.read(EEPROM_UNIT_ID) |
-         (((uint16_t)(EEPROM.read(EEPROM_UNIT_ID + 1))) << 8);
+  return EEPROM.read(EEPROM_UNIT_ID) | (((uint16_t)(EEPROM.read(EEPROM_UNIT_ID + 1))) << 8);
 }
 
 void Arduboy2Base::writeUnitID(uint16_t id)
@@ -1254,11 +1248,7 @@ void Arduboy2::drawChar(int16_t x, int16_t y, unsigned char c, uint8_t color, ui
   bool draw_background = bg != color;
   const unsigned char* bitmap = font + c * 5;
 
-  if ((x >= WIDTH) ||              // Clip right
-      (y >= HEIGHT) ||             // Clip bottom
-      ((x + 5 * size - 1) < 0) ||  // Clip left
-      ((y + 8 * size - 1) < 0)     // Clip top
-     )
+  if ((x >= WIDTH) || (y >= HEIGHT) || ((x + 5 * size - 1) < 0) || ((y + 8 * size - 1) < 0))
   {
     return;
   }

--- a/Arduboy2/Arduboy2Core.cpp
+++ b/Arduboy2/Arduboy2Core.cpp
@@ -113,14 +113,12 @@ void Arduboy2Core::bootPins()
 #ifdef ARDUBOY_10
 
   // Port B INPUT_PULLUP or HIGH
-  PORTB |= _BV(RED_LED_BIT) | _BV(GREEN_LED_BIT) | _BV(BLUE_LED_BIT) |
-           _BV(B_BUTTON_BIT);
+  PORTB |= _BV(RED_LED_BIT) | _BV(GREEN_LED_BIT) | _BV(BLUE_LED_BIT) | _BV(B_BUTTON_BIT);
   // Port B INPUT or LOW (none)
   // Port B inputs
   DDRB &= ~(_BV(B_BUTTON_BIT) | _BV(SPI_MISO_BIT));
   // Port B outputs
-  DDRB |= _BV(RED_LED_BIT) | _BV(GREEN_LED_BIT) | _BV(BLUE_LED_BIT) |
-          _BV(SPI_MOSI_BIT) | _BV(SPI_SCK_BIT) | _BV(SPI_SS_BIT);
+  DDRB |= _BV(RED_LED_BIT) | _BV(GREEN_LED_BIT) | _BV(BLUE_LED_BIT) | _BV(SPI_MOSI_BIT) | _BV(SPI_SCK_BIT) | _BV(SPI_SS_BIT);
 
   // Port C
   // Speaker: Not set here. Controlled by audio class
@@ -141,28 +139,22 @@ void Arduboy2Core::bootPins()
   // Port E outputs (none)
 
   // Port F INPUT_PULLUP or HIGH
-  PORTF |= _BV(LEFT_BUTTON_BIT) | _BV(RIGHT_BUTTON_BIT) |
-           _BV(UP_BUTTON_BIT) | _BV(DOWN_BUTTON_BIT);
+  PORTF |= _BV(LEFT_BUTTON_BIT) | _BV(RIGHT_BUTTON_BIT) | _BV(UP_BUTTON_BIT) | _BV(DOWN_BUTTON_BIT);
   // Port F INPUT or LOW
   PORTF &= ~(_BV(RAND_SEED_IN_BIT));
   // Port F inputs
-  DDRF &= ~(_BV(LEFT_BUTTON_BIT) | _BV(RIGHT_BUTTON_BIT) |
-            _BV(UP_BUTTON_BIT) | _BV(DOWN_BUTTON_BIT) |
-            _BV(RAND_SEED_IN_BIT));
+  DDRF &= ~(_BV(LEFT_BUTTON_BIT) | _BV(RIGHT_BUTTON_BIT) | _BV(UP_BUTTON_BIT) | _BV(DOWN_BUTTON_BIT) | _BV(RAND_SEED_IN_BIT));
   // Port F outputs (none)
 
 #elif defined(AB_DEVKIT)
 
   // Port B INPUT_PULLUP or HIGH
-  PORTB |= _BV(LEFT_BUTTON_BIT) | _BV(UP_BUTTON_BIT) | _BV(DOWN_BUTTON_BIT) |
-           _BV(BLUE_LED_BIT);
+  PORTB |= _BV(LEFT_BUTTON_BIT) | _BV(UP_BUTTON_BIT) | _BV(DOWN_BUTTON_BIT) | _BV(BLUE_LED_BIT);
   // Port B INPUT or LOW (none)
   // Port B inputs
-  DDRB &= ~(_BV(LEFT_BUTTON_BIT) | _BV(UP_BUTTON_BIT) | _BV(DOWN_BUTTON_BIT) |
-            _BV(SPI_MISO_BIT));
+  DDRB &= ~(_BV(LEFT_BUTTON_BIT) | _BV(UP_BUTTON_BIT) | _BV(DOWN_BUTTON_BIT) | _BV(SPI_MISO_BIT));
   // Port B outputs
-  DDRB |= _BV(SPI_MOSI_BIT) | _BV(SPI_SCK_BIT) | _BV(SPI_SS_BIT) |
-          _BV(BLUE_LED_BIT);
+  DDRB |= _BV(SPI_MOSI_BIT) | _BV(SPI_SCK_BIT) | _BV(SPI_SS_BIT) | _BV(BLUE_LED_BIT);
 
   // Port C INPUT_PULLUP or HIGH
   PORTC |= _BV(RIGHT_BUTTON_BIT);
@@ -531,17 +523,14 @@ uint8_t Arduboy2Core::buttonsState()
 
 #ifdef ARDUBOY_10
   // up, right, left, down
-  buttons = ((~PINF) &
-              (_BV(UP_BUTTON_BIT) | _BV(RIGHT_BUTTON_BIT) |
-               _BV(LEFT_BUTTON_BIT) | _BV(DOWN_BUTTON_BIT)));
+  buttons = ((~PINF) & (_BV(UP_BUTTON_BIT) | _BV(RIGHT_BUTTON_BIT) | _BV(LEFT_BUTTON_BIT) | _BV(DOWN_BUTTON_BIT)));
   // A
   if (bitRead(A_BUTTON_PORTIN, A_BUTTON_BIT) == 0) { buttons |= A_BUTTON; }
   // B
   if (bitRead(B_BUTTON_PORTIN, B_BUTTON_BIT) == 0) { buttons |= B_BUTTON; }
 #elif defined(AB_DEVKIT)
   // down, left, up
-  buttons = ((~PINB) &
-              (_BV(DOWN_BUTTON_BIT) | _BV(LEFT_BUTTON_BIT) | _BV(UP_BUTTON_BIT)));
+  buttons = ((~PINB) & (_BV(DOWN_BUTTON_BIT) | _BV(LEFT_BUTTON_BIT) | _BV(UP_BUTTON_BIT)));
   // right
   if (bitRead(RIGHT_BUTTON_PORTIN, RIGHT_BUTTON_BIT) == 0) { buttons |= RIGHT_BUTTON; }
   // A


### PR DESCRIPTION
Ensures that all complex expressions stay on a single line and are not separated into continuations.