### PR TITLE
Reformat functions

### DIFF
--- a/Arduboy2/Arduboy2.cpp
+++ b/Arduboy2/Arduboy2.cpp
@@ -14,7 +14,7 @@
 
 uint8_t Arduboy2Base::sBuffer[];
 
-Arduboy2Base::Arduboy2Base()
+Arduboy2Base::Arduboy2Base(void)
 {
 	currentButtonState = 0;
 	previousButtonState = 0;
@@ -28,7 +28,7 @@ Arduboy2Base::Arduboy2Base()
 // functions called here should be public so users can create their
 // own init functions if they need different behavior than `begin`
 // provides by default
-void Arduboy2Base::begin()
+void Arduboy2Base::begin(void)
 {
 	// raw hardware
 	boot();
@@ -57,7 +57,7 @@ void Arduboy2Base::begin()
 	waitNoButtons();
 }
 
-void Arduboy2Base::flashlight()
+void Arduboy2Base::flashlight(void)
 {
 	if(!pressed(UP_BUTTON))
 		return;
@@ -78,7 +78,7 @@ void Arduboy2Base::flashlight()
 		idle();
 }
 
-void Arduboy2Base::systemButtons()
+void Arduboy2Base::systemButtons(void)
 {
 	while(pressed(B_BUTTON))
 	{
@@ -116,7 +116,7 @@ void Arduboy2Base::sysCtrlSound(uint8_t buttons, uint8_t led, uint8_t eeVal)
 	}
 }
 
-void Arduboy2Base::bootLogo()
+void Arduboy2Base::bootLogo(void)
 {
 	bootLogoShell(drawLogoBitmap);
 }
@@ -126,7 +126,7 @@ void Arduboy2Base::drawLogoBitmap(int16_t y)
 	drawBitmap(20, y, arduboy_logo, 88, 16);
 }
 
-void Arduboy2Base::bootLogoCompressed()
+void Arduboy2Base::bootLogoCompressed(void)
 {
 	bootLogoShell(drawLogoCompressed);
 }
@@ -136,7 +136,7 @@ void Arduboy2Base::drawLogoCompressed(int16_t y)
 	drawCompressed(20, y, arduboy_logo_compressed);
 }
 
-void Arduboy2Base::bootLogoSpritesSelfMasked()
+void Arduboy2Base::bootLogoSpritesSelfMasked(void)
 {
 	bootLogoShell(drawLogoSpritesSelfMasked);
 }
@@ -146,7 +146,7 @@ void Arduboy2Base::drawLogoSpritesSelfMasked(int16_t y)
 	Sprites::drawSelfMasked(20, y, arduboy_logo_sprite, 0);
 }
 
-void Arduboy2Base::bootLogoSpritesOverwrite()
+void Arduboy2Base::bootLogoSpritesOverwrite(void)
 {
 	bootLogoShell(drawLogoSpritesOverwrite);
 }
@@ -156,7 +156,7 @@ void Arduboy2Base::drawLogoSpritesOverwrite(int16_t y)
 	Sprites::drawOverwrite(20, y, arduboy_logo_sprite, 0);
 }
 
-void Arduboy2Base::bootLogoSpritesBSelfMasked()
+void Arduboy2Base::bootLogoSpritesBSelfMasked(void)
 {
 	bootLogoShell(drawLogoSpritesBSelfMasked);
 }
@@ -166,7 +166,7 @@ void Arduboy2Base::drawLogoSpritesBSelfMasked(int16_t y)
 	SpritesB::drawSelfMasked(20, y, arduboy_logo_sprite, 0);
 }
 
-void Arduboy2Base::bootLogoSpritesBOverwrite()
+void Arduboy2Base::bootLogoSpritesBOverwrite(void)
 {
 	bootLogoShell(drawLogoSpritesBOverwrite);
 }
@@ -232,12 +232,12 @@ void Arduboy2Base::bootLogoShell(void (*drawLogo)(int16_t))
 }
 
 // Virtual function overridden by derived class
-void Arduboy2Base::bootLogoExtra()
+void Arduboy2Base::bootLogoExtra(void)
 {
 }
 
 // wait for all buttons to be released
-void Arduboy2Base::waitNoButtons()
+void Arduboy2Base::waitNoButtons(void)
 {
 	do
 	{
@@ -264,7 +264,7 @@ bool Arduboy2Base::everyXFrames(uint8_t frames)
 	return ((frameCount % frames) == 0);
 }
 
-bool Arduboy2Base::nextFrame()
+bool Arduboy2Base::nextFrame(void)
 {
 	const uint8_t now = static_cast<uint8_t>(millis());
 	const uint8_t frameDurationMs = (now - thisFrameStart);
@@ -295,7 +295,7 @@ bool Arduboy2Base::nextFrame()
 	return true;
 }
 
-bool Arduboy2Base::nextFrameDEV()
+bool Arduboy2Base::nextFrameDEV(void)
 {
 	if(!nextFrame())
 		return false;
@@ -308,12 +308,12 @@ bool Arduboy2Base::nextFrameDEV()
 	return true;
 }
 
-int Arduboy2Base::cpuLoad()
+int Arduboy2Base::cpuLoad(void)
 {
 	return ((lastFrameDurationMs * 100) / eachFrameMillis);
 }
 
-void Arduboy2Base::initRandomSeed()
+void Arduboy2Base::initRandomSeed(void)
 {
 	// ADC on
 	power_adc_enable();
@@ -333,7 +333,7 @@ void Arduboy2Base::initRandomSeed()
 
 /* Graphics */
 
-void Arduboy2Base::clear()
+void Arduboy2Base::clear(void)
 {
 	fillScreen(BLACK);
 }
@@ -855,7 +855,7 @@ void Arduboy2Base::fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, 
 	}
 }
 
-void Arduboy2Base::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h, uint8_t color)
+void Arduboy2Base::drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t w, uint8_t h, uint8_t color)
 {
 	// no need to draw at all if we're offscreen
 	if(((x + w) < 0) || (x > (WIDTH - 1)) || ((y + h) < 0) || (y > (HEIGHT - 1)))
@@ -912,7 +912,7 @@ void Arduboy2Base::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8
 }
 
 
-void Arduboy2Base::drawSlowXYBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h, uint8_t color)
+void Arduboy2Base::drawSlowXYBitmap(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t w, uint8_t h, uint8_t color)
 {
 	// no need to draw at all of we're offscreen
 	if(((x + w) < 0) || (x > (WIDTH - 1)) || ((y + h) < 0) || (y > (HEIGHT - 1)))
@@ -935,12 +935,12 @@ void Arduboy2Base::drawSlowXYBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
 // Helper for drawCompressed()
 struct BitStreamReader
 {
-	const uint8_t *source;
+	const uint8_t * source;
 	uint16_t sourceIndex;
 	uint8_t bitBuffer;
 	uint8_t byteBuffer;
 
-	BitStreamReader(const uint8_t *source)
+	BitStreamReader(const uint8_t * source)
 		: source(source), sourceIndex(), bitBuffer(), byteBuffer()
 	{
 	}
@@ -969,7 +969,7 @@ struct BitStreamReader
 	}
 };
 
-void Arduboy2Base::drawCompressed(int16_t sx, int16_t sy, const uint8_t *bitmap, uint8_t color)
+void Arduboy2Base::drawCompressed(int16_t sx, int16_t sy, const uint8_t * bitmap, uint8_t color)
 {
 	// set up decompress state
 	BitStreamReader cs = BitStreamReader(bitmap);
@@ -1071,7 +1071,7 @@ void Arduboy2Base::drawCompressed(int16_t sx, int16_t sy, const uint8_t *bitmap,
 	}
 }
 
-void Arduboy2Base::display()
+void Arduboy2Base::display(void)
 {
 	paintScreen(sBuffer);
 }
@@ -1081,7 +1081,7 @@ void Arduboy2Base::display(bool clear)
 	paintScreen(sBuffer, clear);
 }
 
-uint8_t* Arduboy2Base::getBuffer()
+uint8_t * Arduboy2Base::getBuffer(void)
 {
 	return sBuffer;
 }
@@ -1096,7 +1096,7 @@ bool Arduboy2Base::notPressed(uint8_t buttons)
 	return ((buttonsState() & buttons) == 0);
 }
 
-void Arduboy2Base::pollButtons()
+void Arduboy2Base::pollButtons(void)
 {
 	previousButtonState = currentButtonState;
 	currentButtonState = buttonsState();
@@ -1122,7 +1122,7 @@ bool Arduboy2Base::collide(Rect rect1, Rect rect2)
 	return !((rect2.x >= (rect1.x + rect1.width)) || ((rect2.x + rect2.width) <= rect1.x) || (rect2.y >= (rect1.y + rect1.height)) || ((rect2.y + rect2.height) <= rect1.y));
 }
 
-uint16_t Arduboy2Base::readUnitID()
+uint16_t Arduboy2Base::readUnitID(void)
 {
 	return ((static_cast<uint16_t>(EEPROM.read(EEPROM_UNIT_ID + 0)) << 0) | ((static_cast<uint16_t>(EEPROM.read(EEPROM_UNIT_ID + 1))) << 8));
 }
@@ -1133,7 +1133,7 @@ void Arduboy2Base::writeUnitID(uint16_t id)
 	EEPROM.update(EEPROM_UNIT_ID + 1, (static_cast<uint8_t>(id >> 8) & 0xFF));
 }
 
-uint8_t Arduboy2Base::readUnitName(char* name)
+uint8_t Arduboy2Base::readUnitName(char * name)
 {
 	for(uint8_t dest = 0, src = EEPROM_UNIT_NAME; dest < ARDUBOY_UNIT_NAME_LEN; ++dest, ++src)
 	{
@@ -1151,7 +1151,7 @@ uint8_t Arduboy2Base::readUnitName(char* name)
 	return ARDUBOY_UNIT_NAME_LEN;
 }
 
-void Arduboy2Base::writeUnitName(char* name)
+void Arduboy2Base::writeUnitName(char * name)
 {
 	bool done = false;
 	for(uint8_t src = 0, dest = EEPROM_UNIT_NAME; src < ARDUBOY_UNIT_NAME_LEN; ++src, ++dest)
@@ -1164,7 +1164,7 @@ void Arduboy2Base::writeUnitName(char* name)
 	}
 }
 
-bool Arduboy2Base::readShowBootLogoFlag()
+bool Arduboy2Base::readShowBootLogoFlag(void)
 {
 	return ((EEPROM.read(EEPROM_SYS_FLAGS) & SYS_FLAG_SHOW_LOGO_MASK) != 0);
 }
@@ -1177,7 +1177,7 @@ void Arduboy2Base::writeShowBootLogoFlag(bool val)
 	EEPROM.update(EEPROM_SYS_FLAGS, flags);
 }
 
-bool Arduboy2Base::readShowUnitNameFlag()
+bool Arduboy2Base::readShowUnitNameFlag(void)
 {
 	return ((EEPROM.read(EEPROM_SYS_FLAGS) & SYS_FLAG_UNAME_MASK) != 0);
 }
@@ -1190,7 +1190,7 @@ void Arduboy2Base::writeShowUnitNameFlag(bool val)
 	EEPROM.update(EEPROM_SYS_FLAGS, flags);
 }
 
-bool Arduboy2Base::readShowBootLogoLEDsFlag()
+bool Arduboy2Base::readShowBootLogoLEDsFlag(void)
 {
 	return ((EEPROM.read(EEPROM_SYS_FLAGS) & SYS_FLAG_SHOW_LOGO_LEDS_MASK) != 0);
 }
@@ -1203,7 +1203,7 @@ void Arduboy2Base::writeShowBootLogoLEDsFlag(bool val)
 	EEPROM.update(EEPROM_SYS_FLAGS, flags);
 }
 
-void Arduboy2Base::swap(int16_t& a, int16_t& b)
+void Arduboy2Base::swap(int16_t & a, int16_t & b)
 {
 	const int16_t temp = a;
 	a = b;
@@ -1215,7 +1215,7 @@ void Arduboy2Base::swap(int16_t& a, int16_t& b)
 //========== class Arduboy2 ==========
 //====================================
 
-Arduboy2::Arduboy2()
+Arduboy2::Arduboy2(void)
 {
 	cursor_x = 0;
 	cursor_y = 0;
@@ -1227,7 +1227,7 @@ Arduboy2::Arduboy2()
 
 // bootLogoText() should be kept in sync with bootLogoShell()
 // if changes are made to one, equivalent changes should be made to the other
-void Arduboy2::bootLogoText()
+void Arduboy2::bootLogoText(void)
 {
 	if(!readShowBootLogoFlag())
 		return;
@@ -1285,7 +1285,7 @@ void Arduboy2::bootLogoText()
 	bootLogoExtra();
 }
 
-void Arduboy2::bootLogoExtra()
+void Arduboy2::bootLogoExtra(void)
 {
 	if(!readShowUnitNameFlag())
 		return;
@@ -1371,12 +1371,12 @@ void Arduboy2::setCursor(int16_t x, int16_t y)
 	cursor_y = y;
 }
 
-int16_t Arduboy2::getCursorX()
+int16_t Arduboy2::getCursorX(void)
 {
 	return cursor_x;
 }
 
-int16_t Arduboy2::getCursorY()
+int16_t Arduboy2::getCursorY(void)
 {
 	return cursor_y;
 }
@@ -1386,7 +1386,7 @@ void Arduboy2::setTextColor(uint8_t color)
 	textColor = color;
 }
 
-uint8_t Arduboy2::getTextColor()
+uint8_t Arduboy2::getTextColor(void)
 {
 	return textColor;
 }
@@ -1396,7 +1396,7 @@ void Arduboy2::setTextBackground(uint8_t bg)
 	textBackground = bg;
 }
 
-uint8_t Arduboy2::getTextBackground()
+uint8_t Arduboy2::getTextBackground(void)
 {
 	return textBackground;
 }
@@ -1407,7 +1407,7 @@ void Arduboy2::setTextSize(uint8_t s)
 	textSize = max(1, s);
 }
 
-uint8_t Arduboy2::getTextSize()
+uint8_t Arduboy2::getTextSize(void)
 {
 	return textSize;
 }
@@ -1417,12 +1417,12 @@ void Arduboy2::setTextWrap(bool w)
 	textWrap = w;
 }
 
-bool Arduboy2::getTextWrap()
+bool Arduboy2::getTextWrap(void)
 {
 	return textWrap;
 }
 
-void Arduboy2::clear()
+void Arduboy2::clear(void)
 {
 	Arduboy2Base::clear();
 	cursor_x = 0;

--- a/Arduboy2/Arduboy2.h
+++ b/Arduboy2/Arduboy2.h
@@ -173,7 +173,7 @@ class Arduboy2Base : public Arduboy2Core
  friend class Arduboy2Ex;
 
  public:
-	Arduboy2Base();
+	Arduboy2Base(void);
 
 	/** \brief
 	 * An object created to provide audio control functions within this class.
@@ -202,7 +202,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see boot()
 	 */
-	void begin();
+	void begin(void);
 
 	/** \brief
 	 * Turn the RGB LED and display fully on to act as a small flashlight/torch.
@@ -230,7 +230,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see begin() boot() safeMode()
 	 */
-	void flashlight();
+	void flashlight(void);
 
 	/** \brief
 	 * Handle buttons held on startup for system control.
@@ -248,7 +248,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see begin() boot()
 	 */
-	void systemButtons();
+	void systemButtons(void);
 
 	/** \brief
 	 * Display the boot logo sequence using `drawBitmap()`.
@@ -266,7 +266,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see begin() boot() bootLogoShell() Arduboy2::bootLogoText()
 	 */
-	void bootLogo();
+	void bootLogo(void);
 
 	/** \brief
 	 * Display the boot logo sequence using `drawCompressed()`.
@@ -278,7 +278,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see bootLogo() begin() boot()
 	 */
-	void bootLogoCompressed();
+	void bootLogoCompressed(void);
 
 	/** \brief
 	 * Display the boot logo sequence using `Sprites::drawSelfMasked()`.
@@ -290,7 +290,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see bootLogo() begin() boot() Sprites
 	 */
-	void bootLogoSpritesSelfMasked();
+	void bootLogoSpritesSelfMasked(void);
 
 	/** \brief
 	 * Display the boot logo sequence using `Sprites::drawOverwrite()`.
@@ -302,7 +302,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see bootLogo() begin() boot() Sprites
 	 */
-	void bootLogoSpritesOverwrite();
+	void bootLogoSpritesOverwrite(void);
 
 	/** \brief
 	 * Display the boot logo sequence using `SpritesB::drawSelfMasked()`.
@@ -314,7 +314,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see bootLogo() begin() boot() SpritesB
 	 */
-	void bootLogoSpritesBSelfMasked();
+	void bootLogoSpritesBSelfMasked(void);
 
 	/** \brief
 	 * Display the boot logo sequence using `SpritesB::drawOverwrite()`.
@@ -326,7 +326,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see bootLogo() begin() boot() SpritesB
 	 */
-	void bootLogoSpritesBOverwrite();
+	void bootLogoSpritesBOverwrite(void);
 
 	/** \brief
 	 * Display the boot logo sequence using the provided function
@@ -392,7 +392,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see begin() boot()
 	 */
-	void waitNoButtons();
+	void waitNoButtons(void);
 
 	/** \brief
 	 * Clear the display buffer.
@@ -402,7 +402,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see display(bool)
 	 */
-	void clear();
+	void clear(void);
 
 	/** \brief
 	 * Copy the contents of the display buffer to the display.
@@ -413,7 +413,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see display(bool)
 	 */
-	void display();
+	void display(void);
 
 	/** \brief
 	 * Copy the contents of the display buffer to the display. The display buffer
@@ -623,7 +623,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * The array must be located in program memory by using the PROGMEM modifier.
 	 */
-	static void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h, uint8_t color = WHITE);
+	static void drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t w, uint8_t h, uint8_t color = WHITE);
 
 	/** \brief
 	 * Draw a bitmap from a horizontally oriented array in program memory.
@@ -652,7 +652,7 @@ class Arduboy2Base : public Arduboy2Core
 	 * that allows them to be directly written to the screen. It is recommended
 	 * you use `drawBitmap()` when possible.
 	 */
-	void drawSlowXYBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h, uint8_t color = WHITE);
+	void drawSlowXYBitmap(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t w, uint8_t h, uint8_t color = WHITE);
 
 	/** \brief
 	 * Draw a bitmap from an array of compressed data.
@@ -676,7 +676,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * The array must be located in program memory by using the PROGMEM modifier.
 	 */
-	static void drawCompressed(int16_t sx, int16_t sy, const uint8_t *bitmap, uint8_t color = WHITE);
+	static void drawCompressed(int16_t sx, int16_t sy, const uint8_t * bitmap, uint8_t color = WHITE);
 
 	/** \brief
 	 * Get a pointer to the display buffer in RAM.
@@ -695,7 +695,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see sBuffer
 	 */
-	uint8_t* getBuffer();
+	uint8_t * getBuffer(void);
 
 	/** \brief
 	 * Seed the random number generator with a random value.
@@ -709,10 +709,10 @@ class Arduboy2Base : public Arduboy2Core
 	 * such as after a user hits a button to start a game or other semi-random
 	 * event.
 	 */
-	void initRandomSeed();
+	void initRandomSeed(void);
 
 	// Swap the values of two int16_t variables passed by reference.
-	void swap(int16_t& a, int16_t& b);
+	void swap(int16_t & a, int16_t & b);
 
 	/** \brief
 	 * Set the frame rate used by the frame control functions.
@@ -787,7 +787,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see setFrameRate() setFrameDuration() nextFrameDEV()
 	 */
-	bool nextFrame();
+	bool nextFrame(void);
 
 	/** \brief
 	 * Indicate that it's time to render the next frame, and visually indicate
@@ -814,7 +814,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see nextFrame() cpuLoad() setFrameRate()
 	 */
-	bool nextFrameDEV();
+	bool nextFrameDEV(void);
 
 	/** \brief
 	 * Indicate if the specified number of frames has elapsed.
@@ -864,7 +864,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see setFrameRate() nextFrame()
 	 */
-	int cpuLoad();
+	int cpuLoad(void);
 
 	/** \brief
 	 * Test if the specified buttons are pressed.
@@ -938,7 +938,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see justPressed() justReleased()
 	 */
-	void pollButtons();
+	void pollButtons(void);
 
 	/** \brief
 	 * Check if a button has just been pressed.
@@ -1035,7 +1035,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see writeUnitID() readUnitName()
 	 */
-	uint16_t readUnitID();
+	uint16_t readUnitID(void);
 
 	/** \brief
 	 * Write a unit ID to system EEPROM.
@@ -1086,7 +1086,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see writeUnitName() readUnitID() Arduboy2::bootLogoExtra()
 	 */
-	uint8_t readUnitName(char* name);
+	uint8_t readUnitName(char * name);
 
 	/** \brief
 	 * Write a unit name to system EEPROM.
@@ -1112,7 +1112,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see readUnitName() writeUnitID() Arduboy2::bootLogoExtra()
 	 */
-	void writeUnitName(char* name);
+	void writeUnitName(char * name);
 
 	/** \brief
 	 * Read the "Show Boot Logo" flag in system EEPROM.
@@ -1128,7 +1128,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see writeShowBootLogoFlag() bootLogo()
 	 */
-	bool readShowBootLogoFlag();
+	bool readShowBootLogoFlag(void);
 
 	/** \brief
 	 * Write the "Show Boot Logo" flag in system EEPROM.
@@ -1160,7 +1160,7 @@ class Arduboy2Base : public Arduboy2Core
 	 * \see writeShowUnitNameFlag() writeUnitName() readUnitName()
 	 * Arduboy2::bootLogoExtra()
 	 */
-	bool readShowUnitNameFlag();
+	bool readShowUnitNameFlag(void);
 
 	/** \brief
 	 * Write the "Show Unit Name" flag in system EEPROM.
@@ -1191,7 +1191,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see writeShowBootLogoLEDsFlag()
 	 */
-	bool readShowBootLogoLEDsFlag();
+	bool readShowBootLogoLEDsFlag(void);
 
 	/** \brief
 	 * Write the "Show LEDs with boot logo" flag in system EEPROM.
@@ -1256,7 +1256,7 @@ class Arduboy2Base : public Arduboy2Core
 	 *
 	 * \see getBuffer()
 	 */
-	static uint8_t sBuffer[(HEIGHT*WIDTH)/8];
+	static uint8_t sBuffer[(HEIGHT * WIDTH) / 8];
 
  protected:
 	// helper function for sound enable/disable system control
@@ -1308,7 +1308,7 @@ class Arduboy2 : public Print, public Arduboy2Base
  friend class Arduboy2Ex;
 
  public:
-	Arduboy2();
+	Arduboy2(void);
 
 	/** \class Print
 	 * \brief
@@ -1369,7 +1369,7 @@ class Arduboy2 : public Print, public Arduboy2Base
 	 *
 	 * \see bootLogo() boot() Arduboy2::bootLogoExtra()
 	 */
-	void bootLogoText();
+	void bootLogoText(void);
 
 	/** \brief
 	 * Show the unit name at the bottom of the boot logo screen.
@@ -1391,7 +1391,7 @@ class Arduboy2 : public Print, public Arduboy2Base
 	 * \see readUnitName() writeUnitName() bootLogo() bootLogoShell()
 	 * bootLogoText() writeShowUnitNameFlag() begin()
 	 */
-	virtual void bootLogoExtra();
+	virtual void bootLogoExtra(void);
 
 	/** \brief
 	 * Write a single ASCII character at the current text cursor location.
@@ -1478,7 +1478,7 @@ class Arduboy2 : public Print, public Arduboy2Base
 	 *
 	 * \see getCursorY() setCursor()
 	 */
-	int16_t getCursorX();
+	int16_t getCursorX(void);
 
 	/** \brief
 	 * Get the Y coordinate of the current text cursor position.
@@ -1491,7 +1491,7 @@ class Arduboy2 : public Print, public Arduboy2Base
 	 *
 	 * \see getCursorX() setCursor()
 	 */
-	int16_t getCursorY();
+	int16_t getCursorY(void);
 
 	/** \brief
 	 * Set the text foreground color.
@@ -1509,7 +1509,7 @@ class Arduboy2 : public Print, public Arduboy2Base
 	 *
 	 * \see setTextColor()
 	 */
-	uint8_t getTextColor();
+	uint8_t getTextColor(void);
 
 	/** \brief
 	 * Set the text background color.
@@ -1527,7 +1527,7 @@ class Arduboy2 : public Print, public Arduboy2Base
 	 *
 	 * \see setTextBackground()
 	 */
-	uint8_t getTextBackground();
+	uint8_t getTextBackground(void);
 
 	/** \brief
 	 * Set the text character size.
@@ -1554,7 +1554,7 @@ class Arduboy2 : public Print, public Arduboy2Base
 	 *
 	 * \see setTextSize()
 	 */
-	uint8_t getTextSize();
+	uint8_t getTextSize(void);
 
 	/** \brief
 	 * Set or disable text wrap mode.
@@ -1582,12 +1582,12 @@ class Arduboy2 : public Print, public Arduboy2Base
 	 *
 	 * \see setTextWrap()
 	 */
-	bool getTextWrap();
+	bool getTextWrap(void);
 
 	/** \brief
 	 * Clear the display buffer and set the text cursor to location 0, 0
 	 */
-	void clear();
+	void clear(void);
 
  protected:
 	int16_t cursor_x;

--- a/Arduboy2/Arduboy2Audio.cpp
+++ b/Arduboy2/Arduboy2Audio.cpp
@@ -9,7 +9,7 @@
 
 bool Arduboy2Audio::audio_enabled = false;
 
-void Arduboy2Audio::on()
+void Arduboy2Audio::on(void)
 {
 	// fire up audio pins by seting them as outputs
 #ifdef ARDUBOY_10
@@ -22,7 +22,7 @@ void Arduboy2Audio::on()
 	audio_enabled = true;
 }
 
-void Arduboy2Audio::off()
+void Arduboy2Audio::off(void)
 {
 	audio_enabled = false;
 
@@ -35,7 +35,7 @@ void Arduboy2Audio::off()
 #endif
 }
 
-void Arduboy2Audio::toggle()
+void Arduboy2Audio::toggle(void)
 {
 	if(audio_enabled)
 		off();
@@ -43,12 +43,12 @@ void Arduboy2Audio::toggle()
 		on();
 }
 
-void Arduboy2Audio::saveOnOff()
+void Arduboy2Audio::saveOnOff(void)
 {
 	EEPROM.update(EEPROM_AUDIO_ON_OFF, audio_enabled);
 }
 
-void Arduboy2Audio::begin()
+void Arduboy2Audio::begin(void)
 {
 	if(EEPROM.read(EEPROM_AUDIO_ON_OFF) != 0)
 		on();
@@ -56,7 +56,7 @@ void Arduboy2Audio::begin()
 		off();
 }
 
-bool Arduboy2Audio::enabled()
+bool Arduboy2Audio::enabled(void)
 {
 	return audio_enabled;
 }

--- a/Arduboy2/Arduboy2Audio.h
+++ b/Arduboy2/Arduboy2Audio.h
@@ -85,7 +85,7 @@ class Arduboy2Audio
 	 * `Arduboy2Core::boot()` is used instead of `Arduboy2Base::begin()` and the
 	 * sketch includes sound, then this function should be called after `boot()`.
 	 */
-	void static begin();
+	void static begin(void);
 
 	/** \brief
 	 * Turn sound on.
@@ -97,7 +97,7 @@ class Arduboy2Audio
 	 *
 	 * \see off() toggle() saveOnOff()
 	 */
-	void static on();
+	void static on(void);
 
 	/** \brief
 	 * Turn sound off (mute).
@@ -109,7 +109,7 @@ class Arduboy2Audio
 	 *
 	 * \see on() toggle() saveOnOff()
 	 */
-	void static off();
+	void static off(void);
 
 	/** \brief
 	 * Toggle the sound on/off state.
@@ -122,7 +122,7 @@ class Arduboy2Audio
 	 *
 	 * \see on() off() saveOnOff()
 	 */
-	void static toggle();
+	void static toggle(void);
 
 	/** \brief
 	 * Save the current sound state in EEPROM.
@@ -138,7 +138,7 @@ class Arduboy2Audio
 	 *
 	 * \see on() off() toggle()
 	 */
-	void static saveOnOff();
+	void static saveOnOff(void);
 
 	/** \brief
 	 * Get the current sound state.
@@ -152,7 +152,7 @@ class Arduboy2Audio
 	 *
 	 * \see on() off() toggle()
 	 */
-	bool static enabled();
+	bool static enabled(void);
 
  protected:
 	bool static audio_enabled;

--- a/Arduboy2/Arduboy2Beep.cpp
+++ b/Arduboy2/Arduboy2Beep.cpp
@@ -13,7 +13,7 @@
 
 uint8_t BeepPin1::duration = 0;
 
-void BeepPin1::begin()
+void BeepPin1::begin(void)
 {
 	TCCR3A = 0;
 
@@ -37,7 +37,7 @@ void BeepPin1::tone(uint16_t count, uint8_t dur)
 	OCR3A = count;
 }
 
-void BeepPin1::timer()
+void BeepPin1::timer(void)
 {
 	if(duration == 0)
 		return;
@@ -49,7 +49,7 @@ void BeepPin1::timer()
 		TCCR3A = 0;
 }
 
-void BeepPin1::noTone()
+void BeepPin1::noTone(void)
 {
 	duration = 0;
 
@@ -62,7 +62,7 @@ void BeepPin1::noTone()
 
 uint8_t BeepPin2::duration = 0;
 
-void BeepPin2::begin()
+void BeepPin2::begin(void)
 {
 	// normal mode. Disable PWM
 	TCCR4A = 0;
@@ -99,7 +99,7 @@ void BeepPin2::tone(uint16_t count, uint8_t dur)
 	OCR4C = lowByte(count);
 }
 
-void BeepPin2::timer()
+void BeepPin2::timer(void)
 {
 	if(duration == 0)
 		return;
@@ -111,7 +111,7 @@ void BeepPin2::timer()
 		TCCR4A = 0;
 }
 
-void BeepPin2::noTone()
+void BeepPin2::noTone(void)
 {
 	duration = 0;
 
@@ -128,7 +128,7 @@ void BeepPin2::noTone()
 
 uint8_t BeepPin1::duration = 0;
 
-void BeepPin1::begin()
+void BeepPin1::begin(void)
 {
 }
 
@@ -145,13 +145,13 @@ void BeepPin1::tone(uint16_t count, uint8_t dur)
 	duration = dur;
 }
 
-void BeepPin1::timer()
+void BeepPin1::timer(void)
 {
 	if(duration > 0)
 		--duration;
 }
 
-void BeepPin1::noTone()
+void BeepPin1::noTone(void)
 {
 	duration = 0;
 }
@@ -159,7 +159,7 @@ void BeepPin1::noTone()
 
 uint8_t BeepPin2::duration = 0;
 
-void BeepPin2::begin()
+void BeepPin2::begin(void)
 {
 }
 
@@ -176,13 +176,13 @@ void BeepPin2::tone(uint16_t count, uint8_t dur)
 	duration = dur;
 }
 
-void BeepPin2::timer()
+void BeepPin2::timer(void)
 {
 	if(duration > 0)
 		--duration;
 }
 
-void BeepPin2::noTone()
+void BeepPin2::noTone(void)
 {
 	duration = 0;
 }

--- a/Arduboy2/Arduboy2Beep.h
+++ b/Arduboy2/Arduboy2Beep.h
@@ -153,7 +153,7 @@ class BeepPin1
 	 * This function must be called (usually in `setup()`) before using any of
 	 * the other functions in this class.
 	 */
-	static void begin();
+	static void begin(void);
 
 	/** \brief
 	 * Play a tone continually, until replaced by a new tone or stopped.
@@ -207,7 +207,7 @@ class BeepPin1
 	 * When the `duration` variable is decremented to 0, a playing tone will be
 	 * stopped.
 	 */
-	static void timer();
+	static void timer(void);
 
 	/** \brief
 	 * Stop a tone that is playing.
@@ -218,7 +218,7 @@ class BeepPin1
 	 *
 	 * \see tone()
 	 */
-	static void noTone();
+	static void noTone(void);
 
 	/** \brief
 	 * Convert a frequency to the required count.
@@ -298,7 +298,7 @@ class BeepPin2
 	 * \details
 	 * For details see `BeepPin1::begin()`.
 	 */
-	static void begin();
+	static void begin(void);
 
 	/** \brief
 	 * Play a tone on speaker pin 2 continually, until replaced by a new tone
@@ -330,7 +330,7 @@ class BeepPin2
 	 * \details
 	 * For details see `BeepPin1::timer()`.
 	 */
-	static void timer();
+	static void timer(void);
 
 	/** \brief
 	 * Stop a tone that is playing on speaker pin 2.
@@ -338,7 +338,7 @@ class BeepPin2
 	 * \details
 	 * For details see `BeepPin1::noTone()`.
 	 */
-	static void noTone();
+	static void noTone(void);
 
 	/** \brief
 	 * Convert a frequency to the required count for speaker pin 2.

--- a/Arduboy2/Arduboy2Core.cpp
+++ b/Arduboy2/Arduboy2Core.cpp
@@ -72,11 +72,11 @@ const uint8_t PROGMEM lcdBootProgram[] =
 };
 
 
-Arduboy2Core::Arduboy2Core()
+Arduboy2Core::Arduboy2Core(void)
 {
 }
 
-void Arduboy2Core::boot()
+void Arduboy2Core::boot(void)
 {
 #ifdef ARDUBOY_SET_CPU_8MHZ
 	// ARDUBOY_SET_CPU_8MHZ will be set by the IDE using boards.txt
@@ -97,7 +97,7 @@ void Arduboy2Core::boot()
 // hardware clock on the Arduboy is 16MHz.
 // We also need to readjust the PLL prescaler because the Arduino USB code
 // likely will have incorrectly set it for an 8MHz hardware clock.
-void Arduboy2Core::setCPUSpeed8MHz()
+void Arduboy2Core::setCPUSpeed8MHz(void)
 {
 	const uint8_t oldSREG = SREG;
 
@@ -123,7 +123,7 @@ void Arduboy2Core::setCPUSpeed8MHz()
 
 // Pins are set to the proper modes and levels for the specific hardware.
 // This routine must be modified if any pins are moved to a different port
-void Arduboy2Core::bootPins()
+void Arduboy2Core::bootPins(void)
 {
 #ifdef ARDUBOY_10
 
@@ -223,7 +223,7 @@ void Arduboy2Core::bootPins()
 #endif
 }
 
-void Arduboy2Core::bootOLED()
+void Arduboy2Core::bootOLED(void)
 {
 	// reset the display
 	// reset pin should be low here. let it stay low a while
@@ -248,18 +248,18 @@ void Arduboy2Core::bootOLED()
 	LCDDataMode();
 }
 
-void Arduboy2Core::LCDDataMode()
+void Arduboy2Core::LCDDataMode(void)
 {
 	bitSet(DC_PORT, DC_BIT);
 }
 
-void Arduboy2Core::LCDCommandMode()
+void Arduboy2Core::LCDCommandMode(void)
 {
 	bitClear(DC_PORT, DC_BIT);
 }
 
 // Initialize the SPI interface for the display
-void Arduboy2Core::bootSPI()
+void Arduboy2Core::bootSPI(void)
 {
 	// master, mode 0, MSB first, CPU clock / 2 (8MHz)
 	SPCR = (_BV(SPE) | _BV(MSTR));
@@ -283,7 +283,7 @@ void Arduboy2Core::SPItransfer(uint8_t data)
 	while((SPSR & _BV(SPIF)) == 0);
 }
 
-void Arduboy2Core::safeMode()
+void Arduboy2Core::safeMode(void)
 {
 	if(buttonsState() != UP_BUTTON)
 		return;
@@ -304,7 +304,7 @@ void Arduboy2Core::safeMode()
 
 /* Power Management */
 
-void Arduboy2Core::idle()
+void Arduboy2Core::idle(void)
 {
 	// select idle mode and enable sleeping
 	SMCR = _BV(SE);
@@ -315,7 +315,7 @@ void Arduboy2Core::idle()
 	SMCR = 0;
 }
 
-void Arduboy2Core::bootPowerSaving()
+void Arduboy2Core::bootPowerSaving(void)
 {
 	// disable Two Wire Interface (I2C) and the ADC
 	// All other bits will be written with 0 so will be enabled
@@ -326,7 +326,7 @@ void Arduboy2Core::bootPowerSaving()
 }
 
 // Shut down the display
-void Arduboy2Core::displayOff()
+void Arduboy2Core::displayOff(void)
 {
 	LCDCommandMode();
 
@@ -346,17 +346,17 @@ void Arduboy2Core::displayOff()
 }
 
 // Restart the display after a displayOff()
-void Arduboy2Core::displayOn()
+void Arduboy2Core::displayOn(void)
 {
 	bootOLED();
 }
 
-uint8_t Arduboy2Core::width()
+uint8_t Arduboy2Core::width(void)
 {
 	return WIDTH;
 }
 
-uint8_t Arduboy2Core::height()
+uint8_t Arduboy2Core::height(void)
 {
 	return HEIGHT;
 }
@@ -369,7 +369,7 @@ void Arduboy2Core::paint8Pixels(uint8_t pixels)
 	SPItransfer(pixels);
 }
 
-void Arduboy2Core::paintScreen(const uint8_t *image)
+void Arduboy2Core::paintScreen(const uint8_t * image)
 {
 	for(int i = 0; i < ((HEIGHT * WIDTH) / 8); ++i)
 		SPItransfer(pgm_read_byte(image + i));
@@ -458,7 +458,7 @@ void Arduboy2Core::paintScreen(uint8_t image[], bool clear)
 }
 #endif
 
-void Arduboy2Core::blank()
+void Arduboy2Core::blank(void)
 {
 	for(int i = 0; i < ((HEIGHT * WIDTH) / 8); ++i)
 		SPItransfer(0x00);
@@ -556,7 +556,7 @@ void Arduboy2Core::setRGBled(uint8_t color, uint8_t val)
 #endif
 }
 
-void Arduboy2Core::freeRGBled()
+void Arduboy2Core::freeRGBled(void)
 {
 #ifdef ARDUBOY_10
 	// clear the COM bits to return the pins to normal I/O mode
@@ -610,7 +610,7 @@ void Arduboy2Core::digitalWriteRGB(uint8_t color, uint8_t val)
 
 /* Buttons */
 
-uint8_t Arduboy2Core::buttonsState()
+uint8_t Arduboy2Core::buttonsState(void)
 {
 	uint8_t buttons;
 
@@ -655,7 +655,7 @@ void Arduboy2Core::delayShort(uint16_t ms)
 	delay(static_cast<unsigned long>(ms));
 }
 
-void Arduboy2Core::exitToBootloader()
+void Arduboy2Core::exitToBootloader(void)
 {
 	cli();
 
@@ -678,7 +678,7 @@ void Arduboy2Core::exitToBootloader()
 // Used by the ARDUBOY_NO_USB macro. This should not be called
 // directly from a sketch.
 
-void Arduboy2Core::mainNoUSB()
+void Arduboy2Core::mainNoUSB(void)
 {
 	// disable USB
 	UDCON = _BV(DETACH);

--- a/Arduboy2/Arduboy2Core.h
+++ b/Arduboy2/Arduboy2Core.h
@@ -364,7 +364,7 @@ class Arduboy2Core
 	friend class Arduboy2Ex;
 
 	public:
-		Arduboy2Core();
+		Arduboy2Core(void);
 
 		/** \brief
 		 * Idle the CPU to save power.
@@ -376,7 +376,7 @@ class Arduboy2Core
 		 * app should be able to sleep maybe half the time in between rendering
 		 * it's own frames.
 		 */
-		void static idle();
+		void static idle(void);
 
 		/** \brief
 		 * Put the display into data mode.
@@ -392,7 +392,7 @@ class Arduboy2Core
 		 *
 		 * \see LCDCommandMode() SPItransfer()
 		 */
-		void static LCDDataMode();
+		void static LCDDataMode(void);
 
 		/** \brief
 		 * Put the display into command mode.
@@ -416,7 +416,7 @@ class Arduboy2Core
 		 *
 		 * \see LCDDataMode() sendLCDCommand() SPItransfer()
 		 */
-		void static LCDCommandMode();
+		void static LCDCommandMode(void);
 
 		/** \brief
 		 * Transfer a byte to the display.
@@ -444,7 +444,7 @@ class Arduboy2Core
 		 *
 		 * \see displayOn()
 		 */
-		void static displayOff();
+		void static displayOff(void);
 
 		/** \brief
 		 * Turn the display on.
@@ -460,7 +460,7 @@ class Arduboy2Core
 		 *
 		 * \see displayOff()
 		 */
-		void static displayOn();
+		void static displayOn(void);
 
 		/** \brief
 		 * Get the width of the display in pixels.
@@ -471,7 +471,7 @@ class Arduboy2Core
 		 * In most cases, the defined value `WIDTH` would be better to use instead
 		 * of this function.
 		 */
-		uint8_t static width();
+		uint8_t static width(void);
 
 		/** \brief
 		 * Get the height of the display in pixels.
@@ -482,7 +482,7 @@ class Arduboy2Core
 		 * In most cases, the defined value `HEIGHT` would be better to use instead
 		 * of this function.
 		 */
-		uint8_t static height();
+		uint8_t static height(void);
 
 		/** \brief
 		 * Get the current state of all buttons as a bitmask.
@@ -497,7 +497,7 @@ class Arduboy2Core
 		 *
 		 * LEFT_BUTTON, RIGHT_BUTTON, UP_BUTTON, DOWN_BUTTON, A_BUTTON, B_BUTTON
 		 */
-		uint8_t static buttonsState();
+		uint8_t static buttonsState(void);
 
 		/** \brief
 		 * Paint 8 pixels vertically to the display.
@@ -547,7 +547,7 @@ class Arduboy2Core
 		 *
 		 * \see paint8Pixels()
 		 */
-		void static paintScreen(const uint8_t *image);
+		void static paintScreen(const uint8_t * image);
 
 		/** \brief
 		 * Paints an entire image directly to the display from an array in RAM.
@@ -580,7 +580,7 @@ class Arduboy2Core
 		 * All pixels on the screen will be written with a value of 0 to turn
 		 * them off.
 		 */
-		void static blank();
+		void static blank(void);
 
 		/** \brief
 		 * Invert the entire display or set it back to normal.
@@ -739,7 +739,7 @@ class Arduboy2Core
 		 *
 		 * \see digitalWriteRGB() setRGBled()
 		 */
-		void static freeRGBled();
+		void static freeRGBled(void);
 
 		/** \brief
 		 * Set the RGB LEDs digitally, to either fully on or fully off.
@@ -819,7 +819,7 @@ class Arduboy2Core
 		 *
 		 * \see Arduboy2Base::begin()
 		 */
-		void static boot();
+		void static boot(void);
 
 		/** \brief
 		 * Allow upload when the bootloader "magic number" could be corrupted.
@@ -840,7 +840,7 @@ class Arduboy2Core
 		 *
 		 * \see Arduboy2Base::flashlight() boot()
 		 */
-		void static safeMode();
+		void static safeMode(void);
 
 		/** \brief
 		 * Delay for the number of milliseconds, specified as a 16 bit value.
@@ -871,20 +871,20 @@ class Arduboy2Core
 		 *
 		 * \see ARDUBOY_NO_USB
 		 */
-		void static exitToBootloader();
+		void static exitToBootloader(void);
 
 		// Replacement main() that eliminates the USB stack code.
 		// Used by the ARDUBOY_NO_USB macro. This should not be called
 		// directly from a sketch.
-		void static mainNoUSB();
+		void static mainNoUSB(void);
 
 	protected:
 		// internals
-		void static setCPUSpeed8MHz();
-		void static bootSPI();
-		void static bootOLED();
-		void static bootPins();
-		void static bootPowerSaving();
+		void static setCPUSpeed8MHz(void);
+		void static bootSPI(void);
+		void static bootOLED(void);
+		void static bootPins(void);
+		void static bootPowerSaving(void);
 };
 
 #endif

--- a/Arduboy2/Sprites.cpp
+++ b/Arduboy2/Sprites.cpp
@@ -6,34 +6,34 @@
 
 #include "Sprites.h"
 
-void Sprites::drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t frame, uint8_t mask_frame)
+void Sprites::drawExternalMask(int16_t x, int16_t y, const uint8_t * bitmap, const uint8_t * mask, uint8_t frame, uint8_t mask_frame)
 {
 	draw(x, y, bitmap, frame, mask, mask_frame, SPRITE_MASKED);
 }
 
-void Sprites::drawOverwrite(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame)
+void Sprites::drawOverwrite(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame)
 {
 	draw(x, y, bitmap, frame, NULL, 0, SPRITE_OVERWRITE);
 }
 
-void Sprites::drawErase(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame)
+void Sprites::drawErase(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame)
 {
 	draw(x, y, bitmap, frame, NULL, 0, SPRITE_IS_MASK_ERASE);
 }
 
-void Sprites::drawSelfMasked(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame)
+void Sprites::drawSelfMasked(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame)
 {
 	draw(x, y, bitmap, frame, NULL, 0, SPRITE_IS_MASK);
 }
 
-void Sprites::drawPlusMask(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame)
+void Sprites::drawPlusMask(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame)
 {
 	draw(x, y, bitmap, frame, NULL, 0, SPRITE_PLUS_MASK);
 }
 
 
 //common functions
-void Sprites::draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, const uint8_t *mask, uint8_t sprite_frame, uint8_t drawMode)
+void Sprites::draw(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame, const uint8_t * mask, uint8_t sprite_frame, uint8_t drawMode)
 {
 	if(bitmap == NULL)
 		return;
@@ -65,7 +65,7 @@ void Sprites::draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, c
 	drawBitmap(x, y, bitmap, mask, width, height, drawMode);
 }
 
-void Sprites::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t w, uint8_t h, uint8_t draw_mode)
+void Sprites::drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, const uint8_t * mask, uint8_t w, uint8_t h, uint8_t draw_mode)
 {
 	// no need to draw at all of we're offscreen
 	if(((x + w) <= 0) || (x > (WIDTH - 1)) || ((y + h) <= 0) || (y > (HEIGHT - 1)))

--- a/Arduboy2/Sprites.h
+++ b/Arduboy2/Sprites.h
@@ -109,7 +109,7 @@ class Sprites
 		 *     --#--  #####  #####   --#--
 		 *     -----  -###-  #####   #---#
 		 */
-		static void drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t frame, uint8_t mask_frame);
+		static void drawExternalMask(int16_t x, int16_t y, const uint8_t * bitmap, const uint8_t * mask, uint8_t frame, uint8_t mask_frame);
 
 		/** \brief
 		 * Draw a sprite using an array containing both image and mask values.
@@ -145,7 +145,7 @@ class Sprites
 		 *     --#--  #####  #####   --#--
 		 *     -----  -###-  #####   #---#
 		 */
-		static void drawPlusMask(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame);
+		static void drawPlusMask(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame);
 
 		/** \brief
 		 * Draw a sprite by replacing the existing content completely.
@@ -176,7 +176,7 @@ class Sprites
 		 *     --#--  #####   --#--
 		 *     -----  #####   -----
 		 */
-		static void drawOverwrite(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame);
+		static void drawOverwrite(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame);
 
 		/** \brief
 		 * "Erase" a sprite.
@@ -207,7 +207,7 @@ class Sprites
 		 *     --#--  #####   ##-##
 		 *     -----  #####   #####
 		 */
-		static void drawErase(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame);
+		static void drawErase(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame);
 
 		/** \brief
 		 * Draw a sprite using only the bits set to 1.
@@ -237,15 +237,15 @@ class Sprites
 		 *     --#--  #####   #####
 		 *     -----  #####   #####
 		 */
-		static void drawSelfMasked(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame);
+		static void drawSelfMasked(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame);
 
 		// Master function. Needs to be abstracted into separate function for
 		// every render type.
 		// (Not officially part of the API)
-		static void draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, const uint8_t *mask, uint8_t sprite_frame, uint8_t drawMode);
+		static void draw(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame, const uint8_t * mask, uint8_t sprite_frame, uint8_t drawMode);
 
 		// (Not officially part of the API)
-		static void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t w, uint8_t h, uint8_t draw_mode);
+		static void drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, const uint8_t * mask, uint8_t w, uint8_t h, uint8_t draw_mode);
 };
 
 #endif

--- a/Arduboy2/SpritesB.cpp
+++ b/Arduboy2/SpritesB.cpp
@@ -7,34 +7,34 @@
 
 #include "SpritesB.h"
 
-void SpritesB::drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t frame, uint8_t mask_frame)
+void SpritesB::drawExternalMask(int16_t x, int16_t y, const uint8_t * bitmap, const uint8_t * mask, uint8_t frame, uint8_t mask_frame)
 {
 	draw(x, y, bitmap, frame, mask, mask_frame, SPRITE_MASKED);
 }
 
-void SpritesB::drawOverwrite(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame)
+void SpritesB::drawOverwrite(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame)
 {
 	draw(x, y, bitmap, frame, NULL, 0, SPRITE_OVERWRITE);
 }
 
-void SpritesB::drawErase(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame)
+void SpritesB::drawErase(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame)
 {
 	draw(x, y, bitmap, frame, NULL, 0, SPRITE_IS_MASK_ERASE);
 }
 
-void SpritesB::drawSelfMasked(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame)
+void SpritesB::drawSelfMasked(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame)
 {
 	draw(x, y, bitmap, frame, NULL, 0, SPRITE_IS_MASK);
 }
 
-void SpritesB::drawPlusMask(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame)
+void SpritesB::drawPlusMask(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame)
 {
 	draw(x, y, bitmap, frame, NULL, 0, SPRITE_PLUS_MASK);
 }
 
 
 //common functions
-void SpritesB::draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, const uint8_t *mask, uint8_t sprite_frame, uint8_t drawMode)
+void SpritesB::draw(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame, const uint8_t * mask, uint8_t sprite_frame, uint8_t drawMode)
 {
 	if(bitmap == NULL)
 		return;
@@ -66,7 +66,7 @@ void SpritesB::draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, 
 	drawBitmap(x, y, bitmap, mask, width, height, drawMode);
 }
 
-void SpritesB::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t w, uint8_t h, uint8_t draw_mode)
+void SpritesB::drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, const uint8_t * mask, uint8_t w, uint8_t h, uint8_t draw_mode)
 {
 	// no need to draw at all of we're offscreen
 	if(((x + w) <= 0) || (x > (WIDTH - 1)) || ((y + h) <= 0) || (y > (HEIGHT - 1)))

--- a/Arduboy2/SpritesB.h
+++ b/Arduboy2/SpritesB.h
@@ -52,7 +52,7 @@ class SpritesB
 		 *
 		 * \see Sprites::drawExternalMask()
 		 */
-		static void drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t frame, uint8_t mask_frame);
+		static void drawExternalMask(int16_t x, int16_t y, const uint8_t * bitmap, const uint8_t * mask, uint8_t frame, uint8_t mask_frame);
 
 		/** \brief
 		 * Draw a sprite using an array containing both image and mask values.
@@ -63,7 +63,7 @@ class SpritesB
 		 *
 		 * \see Sprites::drawPlusMask()
 		 */
-		static void drawPlusMask(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame);
+		static void drawPlusMask(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame);
 
 		/** \brief
 		 * Draw a sprite by replacing the existing content completely.
@@ -74,7 +74,7 @@ class SpritesB
 		 *
 		 * \see Sprites::drawOverwrite()
 		 */
-		static void drawOverwrite(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame);
+		static void drawOverwrite(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame);
 
 		/** \brief
 		 * "Erase" a sprite.
@@ -85,7 +85,7 @@ class SpritesB
 		 *
 		 * \see Sprites::drawErase()
 		 */
-		static void drawErase(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame);
+		static void drawErase(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame);
 
 		/** \brief
 		 * Draw a sprite using only the bits set to 1.
@@ -96,15 +96,15 @@ class SpritesB
 		 *
 		 * \see Sprites::drawSelfMasked()
 		 */
-		static void drawSelfMasked(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame);
+		static void drawSelfMasked(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame);
 
 		// Master function. Needs to be abstracted into separate function for
 		// every render type.
 		// (Not officially part of the API)
-		static void draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, const uint8_t *mask, uint8_t sprite_frame, uint8_t drawMode);
+		static void draw(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frame, const uint8_t * mask, uint8_t sprite_frame, uint8_t drawMode);
 
 		// (Not officially part of the API)
-		static void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t w, uint8_t h, uint8_t draw_mode);
+		static void drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, const uint8_t * mask, uint8_t w, uint8_t h, uint8_t draw_mode);
 };
 
 #endif


### PR DESCRIPTION
Reformats the functions' declarations and definitions.
Uses explicit void for functions with no arguments.
Changes pointers to 'middle style'.