### PR TITLE
Fix initRandomSeed implementation

### DIFF
--- a/Arduboy2/Arduboy2.cpp
+++ b/Arduboy2/Arduboy2.cpp
@@ -325,7 +325,7 @@ int Arduboy2Base::cpuLoad(void)
 
 void Arduboy2Base::initRandomSeed(void)
 {
-	Pokitto::Core::initRandom();
+	srandom(Pokitto::Core::getTime());
 }
 
 /* Graphics */


### PR DESCRIPTION
Pokitto's Pokitto::Core::initRandom function wasn't providing sufficient randomness for some reason.
It has been replaced by feeding the result of Pokitto::Core::getTime to srandom.